### PR TITLE
Fix: Allow webpack v4 "Module" import

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ### Installing
 
 ```Bash
-npm install moducks@1.0.0-beta.3 --save
+npm install moducks@1.0.0-beta.4 --save
 ```
 
 ### Contents

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moducks",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "main": "lib/index.js",
   "module": "es/index.js",
   "scripts": {

--- a/src/schema.js
+++ b/src/schema.js
@@ -3,8 +3,16 @@ import yup from 'yup'
 const requiredFn = yup.mixed().test('required-function', '${path} is not a function', v => typeof v === 'function')
 const nonRequiredFn = yup.mixed().test('non-required-function', '${path} is not a function', v => v === undefined || typeof v === 'function')
 
-const schema = yup.object().shape({
-  effects: yup.object().required().when('defaultEffect', (defaultEffect, schema) => schema.shape({
+const effects = yup
+  .object()
+  .transform((currentValue, originalValue) =>
+    // in webpack v4, wildcard import type is not "Object" but "Module"
+    originalValue && originalValue[Symbol.toStringTag] === 'Module'
+      ? Object.create(null, originalValue)
+      : currentValue
+  )
+  .required()
+  .when('defaultEffect', (defaultEffect, schema) => schema.shape({
     put: requiredFn,
     fork: requiredFn,
     spawn: nonRequiredFn,
@@ -12,8 +20,13 @@ const schema = yup.object().shape({
     takeEvery: defaultEffect === 'takeEvery' ? requiredFn : nonRequiredFn,
     takeLeading: defaultEffect === 'takeLeading' ? requiredFn : nonRequiredFn,
     takeLatest: defaultEffect === 'takeLatest' ? requiredFn : nonRequiredFn,
-  })),
-  defaultEffect: yup.string().oneOf(['takeEvery', 'takeLeading', 'takeLatest']).default('takeEvery'),
-})
+  }))
+
+const defaultEffect = yup
+  .string()
+  .oneOf(['takeEvery', 'takeLeading', 'takeLatest'])
+  .default('takeEvery')
+
+const schema = yup.object().shape({ effects, defaultEffect })
 
 export default schema


### PR DESCRIPTION
https://github.com/jquense/yup/blob/4088e7d6728dad1eee9e0e3bb7570b09ceba7de5/src/object.js#L16

```js
// webpack v3
import * as effects from 'redux-saga/effects'
console.log(Object.prototype.toString.call(effects)) // [object Object]
```

```js
// webpack v4
import * as effects from 'redux-saga/effects'
console.log(Object.prototype.toString.call(effects)) // [object Module]
```